### PR TITLE
Fix relative paths inside `{{ content }}`

### DIFF
--- a/docs/_includes/base.html
+++ b/docs/_includes/base.html
@@ -1,0 +1,6 @@
+{% assign base = '.' %}
+{% assign depth = page.url | split: '/' | size | minus: 0 %}
+{% if    depth == 1 %}{% assign base = '.' %}
+{% elsif depth == 2 %}{% assign base = '..' %}
+{% elsif depth == 3 %}{% assign base = '../..' %}
+{% elsif depth == 4 %}{% assign base = '../../..' %}{% endif %}

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,10 +1,4 @@
 <head>
-  {% assign base = '.' %}
-  {% assign depth = page.url | split: '/' | size | minus: 0 %}
-  {% if    depth == 1 %}{% assign base = '.' %}
-  {% elsif depth == 2 %}{% assign base = '..' %}
-  {% elsif depth == 3 %}{% assign base = '../..' %}
-  {% elsif depth == 4 %}{% assign base = '../../..' %}{% endif %}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>{% if page.title %}{{ site.title }} {{ site.version }} &mdash; {{ page.title }}{% else %}{{ site.title }} {{ site.version }}{% endif %}</title>
@@ -20,7 +14,7 @@
   <link rel="shortcut icon" href="http://cdn.wfp.org/favicon.ico">
   <link rel="stylesheet" href="http://cdn.wfp.org/libraries/webfonts/lato/lato.css">
   <link rel="stylesheet" href="http://cdn.wfp.org/libraries/webfonts/aleo/aleo.css">
-  <link href="{{base}}/img/icons/ui/ui-icons.svg.css" rel="stylesheet">
-  <link href="{{base}}/img/icons/thematic/thematic-icons.svg.css" rel="stylesheet">
-  <link href="{{base}}/css/main.css" rel="stylesheet">
+  <link href="{{ base }}/img/icons/ui/ui-icons.svg.css" rel="stylesheet">
+  <link href="{{ base }}/img/icons/thematic/thematic-icons.svg.css" rel="stylesheet">
+  <link href="{{ base }}/css/main.css" rel="stylesheet">
 </head>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+  {% include base.html %}
   {% include head.html %}
   <body class="wfp-header-spacer--narrow">
 
@@ -16,10 +17,10 @@
 
     {% include footer.html %}
 
-    <script src="{{base}}/js/lib/jquery.js"></script>
-    <script src="{{base}}/js/lib/responsive-nav.js"></script>
-    <script src="{{base}}/js/plugins.js"></script>
-    <script src="{{base}}/js/main.js"></script>
+    <script src="{{ base }}/js/lib/jquery.js"></script>
+    <script src="{{ base }}/js/lib/responsive-nav.js"></script>
+    <script src="{{ base }}/js/plugins.js"></script>
+    <script src="{{ base }}/js/main.js"></script>
     {% if page.path == 'component-1-header.md' %}
     <script>
       var navExample = responsiveNav('#js-example-menu', {

--- a/docs/basics-1-principles.md
+++ b/docs/basics-1-principles.md
@@ -5,6 +5,7 @@ permalink: /basics/principles/
 resource: true
 categories: Basics
 ---
+{% include base.html %}
 
 To create a great User Interface you have to keep a few things in mind. Those things are: *hierarchy*, *alignment* and *simplicity*. It's easy to do if you adhere to the following guidelines:
 

--- a/docs/basics-2-branding.md
+++ b/docs/basics-2-branding.md
@@ -6,6 +6,8 @@ resource: true
 categories: Basics
 ---
 
+{% include base.html %}
+
 ### Logo
 WFP logo is available in three versions: _emblem_, _standard_, and _full_. Each has its own purpose and should be used appropriately, as per [official branding guidelines](wfp.org/branding), depending on available screen space and target audience.
 

--- a/docs/basics-3-typography.md
+++ b/docs/basics-3-typography.md
@@ -6,6 +6,7 @@ resource: true
 categories: Basics
 nav: nav/typography.html
 ---
+{% include base.html %}
 
 Typography plays a critical role in any design; in fact, it accounts for as much as 95% of everything we see on the Web. When done well, it adds personality to content, becomes its voice. When established poorly, typographic elements become unreadable, thus reducing the impact a given piece of content will have on the reader.
 

--- a/docs/basics-4-content.md
+++ b/docs/basics-4-content.md
@@ -6,6 +6,7 @@ resource: true
 categories: Basics
 nav: nav/content.html
 ---
+{% include base.html %}
 
 ### Headings
 Headings are a useful tool to markup important sections of a given page, such as headlines, chapters, etc. Any heading elements may include links or anchors.

--- a/docs/basics-5-getting-started.md
+++ b/docs/basics-5-getting-started.md
@@ -5,6 +5,7 @@ permalink: /basics/getting-started/
 resource: true
 categories: Basics
 ---
+{% include base.html %}
 
 To make sure your interface follows WFP guidelines with ease, you should use the provided UI kit in your web pages and applications. We offer a number of ways to include WFP UI in your projects.
 

--- a/docs/component-0-header.md
+++ b/docs/component-0-header.md
@@ -5,6 +5,7 @@ permalink: /component/header/
 resource: true
 categories: Components
 ---
+{% include base.html %}
 
 This pattern is the single, most important way to indicate to your visitors that they are browsing WFP's online property. Below, you will find most commonly used patterns for your header.
 

--- a/docs/component-1-footer.md
+++ b/docs/component-1-footer.md
@@ -5,6 +5,7 @@ permalink: /component/footer/
 resource: true
 categories: Components
 ---
+{% include base.html %}
 
 Footer is the second most important place where your basic site information and links should live. Users turn often to the footer to look for important information, such as contact details, or links to less prominent sections of the website (privacy policy, terms of use, etc).
 

--- a/docs/component-2-navigation.md
+++ b/docs/component-2-navigation.md
@@ -6,6 +6,7 @@ resource: true
 categories: Components
 nav: nav/navigation.html
 ---
+{% include base.html %}
 
 This is one of the most important components for all websites and applications. Without good navigation the content cannot be discovered by the user, nor the user will be able to navigate between your pages with ease. WFP UI offers several navigation patterns, depending on the use case.
 

--- a/docs/component-3-forms.md
+++ b/docs/component-3-forms.md
@@ -6,6 +6,7 @@ resource: true
 categories: Components
 nav: nav/forms.html
 ---
+{% include base.html %}
 
 Forms are an important part of pages which ask users for input. They should be simple, clear and accessible for all audiences. Below you can find several important components from which the forms are assembled.
 

--- a/docs/component-4-tables.md
+++ b/docs/component-4-tables.md
@@ -5,6 +5,7 @@ permalink: /components/tables/
 resource: true
 categories: Components
 ---
+{% include base.html %}
 
 ### Standard
 Tables should use a `wfp-table` class, and be properly structured, using `<thead>` and `<tbody>`, in order to achieve best results.

--- a/docs/component-5-buttons.md
+++ b/docs/component-5-buttons.md
@@ -6,6 +6,7 @@ resource: true
 categories: Components
 nav: nav/buttons.html
 ---
+{% include base.html %}
 
 We use several buttons for you to choose from, make sure you apply only styles intended for a given element, to make sure it doesn't stand out too much or doesn't bear a different meaning.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: WFP UI Guidelines
 ---
+{% include base.html %}
 
 The World Food Programme’s (WFP) [Branding Guidance](http://www.wfp.org/Branding) (PDF, 4.7MB) was published in 2009 and has now been effectively implemented across the organization, strengthening WFP's brand image through consistent representation.
 

--- a/docs/info-0-about.md
+++ b/docs/info-0-about.md
@@ -5,6 +5,7 @@ permalink: /about/
 resource: true
 categories: Info
 ---
+{% include base.html %}
 
 ### Project Versioning
 _WFP UI_ uses _Semantic Versioning_ (SemVer) philosophy, but adjusted for this project specifically. The following rules take precedence over SemVer:

--- a/docs/patterns-3-validation.md
+++ b/docs/patterns-3-validation.md
@@ -6,6 +6,7 @@ resource: true
 categories: Patterns
 nav: nav/validation.html
 ---
+{% include base.html %}
 
 When designing forms, you should not forget to apply inline validation to them. This will ensure that whoever is asked to fill it in, will be instantly prompted to correct a mistake, should it occur, before submitting the form.
 

--- a/docs/resources-1-fonts.md
+++ b/docs/resources-1-fonts.md
@@ -5,6 +5,7 @@ permalink: /resources/fonts/
 resource: true
 categories: Resources
 ---
+{% include base.html %}
 
 Fonts should be loaded from WFP's Content Delivery Network:
 
@@ -26,4 +27,3 @@ font-family: "aleo", serif;
 {% endhighlight %}
 
 Our webfonts are also available for offline use, and come bundled with WFP UI, which you can [download from GitHub](https://github.com/wfp/ui/releases). You can reference them from `dist` directory.
-

--- a/docs/resources-3-favicons.md
+++ b/docs/resources-3-favicons.md
@@ -5,6 +5,7 @@ permalink: /resources/favicons/
 resource: true
 categories: Resources
 ---
+{% include base.html %}
 
 Favicons are small icons that are being often displayed in the browser address bar, stored with bookmarked pages, etc. You should only use the officialy approved favicons.
 

--- a/docs/resources-4-icons-thematic.md
+++ b/docs/resources-4-icons-thematic.md
@@ -5,6 +5,7 @@ permalink: /resources/thematic-icons/
 resource: true
 categories: Resources
 ---
+{% include base.html %}
 
 The _Office for the Coordination of Humanitarian Affairs_ (OCHA) has established icons to represent humanitarian assistance and to ensure consistency in use, these have been shared widely with UN agencies and NGOs. On this section we have listed those OCHA icons that WFP uses most frequently in addition to a few WFP-specific ones.
 

--- a/docs/resources-5-icons-ui.md
+++ b/docs/resources-5-icons-ui.md
@@ -5,6 +5,7 @@ permalink: /resources/ui-icons/
 resource: true
 categories: Resources
 ---
+{% include base.html %}
 
 User Interface Icons should be used to strengthen visual cues; use them wisely and do not overload the interface with icons.
 

--- a/docs/resources-5-icons-ui.md
+++ b/docs/resources-5-icons-ui.md
@@ -117,7 +117,7 @@ By default, all UI icons are displayed in `24 x 24px` size. You can easily adjus
 {% directory path:img/icons/ui/png %}
   <li class="item wfp-u-1-2">
     <div class="desc">
-      <div class="desc-img {% cycle 'light', 'dark' %}"><img src="{{ site.baseurl }}/img/icons/ui/png/{{ file.name }}"></div>
+      <div class="desc-img {% cycle 'light', 'dark' %}"><img src="{{ base }}/img/icons/ui/png/{{ file.name }}"></div>
       <div class="desc-label">{{ file.slug }}</div>
     </div>
   </li>


### PR DESCRIPTION
Recently introduced relative path trick doesn't work by default inside a `{{ content }}` tag, due Jekyll not being able to deal with user content directly (only through YAML and Liquid).

That means we cannot even pass any variables generated within layouts to our content via `{{ content }}`, because the latter is a pre-compiled YAML/MD template, which then Liquid only adds to the mix.

The solution was to move the `{{ base }}` generation to a partial and call it from within all `.md` files.

Refs #32