### PR TITLE
feat(MainNavigation): Add a prop to set the sub navigation dropdown wide as its content

### DIFF
--- a/src/components/MainNavigation/MainNavigation.js
+++ b/src/components/MainNavigation/MainNavigation.js
@@ -32,11 +32,13 @@ class MainNavigationItem extends Component {
       menuItem,
       onChangeSub,
       subNavigation,
+      subNavWideAsContent,
     } = this.props;
 
     const wrapperClasses = classNames(className, {
       'wfp--main-navigation__item': true,
       'wfp--main-navigation__item--open': menuItem === activeMenuItem,
+      'wfp--content-width': subNavigation && subNavWideAsContent,
     });
 
     const triggerClasses = classNames({
@@ -195,6 +197,11 @@ MainNavigation.propTypes = {
   className: PropTypes.string,
   id: PropTypes.string,
   wrapperClassName: PropTypes.string,
+};
+
+MainNavigationItem.propTypes = {
+  /** Sets the width of the SubNavigation container based on its content */
+  subNavWideAsContent: PropTypes.bool,
 };
 
 MainNavigation.defaultProps = {

--- a/src/components/MainNavigation/_main-navigation.scss
+++ b/src/components/MainNavigation/_main-navigation.scss
@@ -137,6 +137,20 @@
 
     .#{$prefix}--main-navigation__item {
       padding: 0 $spacing-sm;
+
+      // Relate the sub navigation dropdown to the parent navigation item
+      &.#{$prefix}--content-width {
+        position: relative;
+
+        // Get the width from its navigation content
+        & > .#{$prefix}--main-navigation__sub--open {
+          left: inherit;
+          min-width: 100%;
+          right: 0;
+          top: 2.5rem;
+          width: auto;
+        }
+      }
     }
 
     .#{$prefix}--main-navigation__button {


### PR DESCRIPTION
@Utzel-Butzel 

The width of the SubNavigation container is 100% by default.
I added a prop to optionally make this container wide as its content.

#### Changelog

**New**

* Added `subNavWideAsContent` prop to `MainNavigation`
* Added styles related to `subNavWideAsContent` prop in `_main-navigation.scss`