### PR TITLE
Update Tab.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.11.0](https://github.com/WFP/UI/compare/v1.10.20...v1.11.0) (2020-12-08)
+
+
+### Features
+
+* **package:** trigger release ([cbabcd3](https://github.com/WFP/UI/commit/cbabcd387543fec65dcc63a2b6f5ddf0846bdb93))
+
 ## [1.10.12](https://github.com/WFP/UI/compare/v1.10.11...v1.10.12) (2020-11-25)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wfp/ui",
-  "version": "1.10.12",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wfp/ui",
-  "version": "1.10.11",
+  "version": "1.11.0",
   "description": "WFP UI Kit Next",
   "license": "Apache-2",
   "main": "lib/index.js",

--- a/src/components/Tab/Tab.js
+++ b/src/components/Tab/Tab.js
@@ -87,7 +87,7 @@ export default class Tab extends React.Component {
     /*
      * An optional parameter to allow overriding the list element rendering.
      **/
-    renderListElement: PropTypes.node,
+    renderListElement: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   };
 
   static defaultProps = {


### PR DESCRIPTION
Passing a functional component throws a warning to the console. Example:

const listElement = (elementProps) => (
    <Route
      to={elementProps.to}
      exact={elementProps.exact}
      children={
        <li className={elementProps.className + " wfp--tabs__nav-item"}>
          <NavLink
            to={elementProps.to}
            onClick={(_) => setSelectedTab(elementProps.index)}
          >
            {elementProps.anchor.label}
          </NavLink>
        </li>
      }
    />
  );

...

renderListElement={listEl}

#### Changelog

**Changed**

Tab component PropTypes for renderListElement prop.

