### PR TITLE
Fix small typo in install instructions

### DIFF
--- a/src/documentation/Usage/UsageDevelopers.stories.mdx
+++ b/src/documentation/Usage/UsageDevelopers.stories.mdx
@@ -32,7 +32,7 @@ An example implementation using `create-react-app` and `scss` can be found in ou
 
 ## 2. Add the Kit as a dependency
 
-The next step is to **add the Kit to your project as a dependancy**. You can choose to install it through `npm` or `yarn`: they are both valid package managers and we don't want to recommend one over the other, but once you pick your favourite tool, simply stick with it and avoid using them simultaneously.
+The next step is to **add the Kit to your project as a dependency**. You can choose to install it through `npm` or `yarn`: they are both valid package managers and we don't want to recommend one over the other, but once you pick your favourite tool, simply stick with it and avoid using them simultaneously.
 
 To install the Kit through `npm`, run:
 


### PR DESCRIPTION
Spotted while reading https://uikit.wfp.org/docs/index.html?path=/docs/getting-started-installing-the-kit--page.