### PR TITLE
fix(create-design-system): resolve lerna error, correct docs

### DIFF
--- a/packages/create-design-system/install.js
+++ b/packages/create-design-system/install.js
@@ -95,7 +95,7 @@ async function main() {
 
   console.log('Lerna init...');
 
-  proc.execSync('lerna init');
+  proc.execSync('npx lerna init');
 
   //console.log('Removing useless files');
   //proc.execSync('npx rimraf ./.git');

--- a/packages/create-design-system/readme.md
+++ b/packages/create-design-system/readme.md
@@ -7,7 +7,7 @@ Create Design System is a tool to initialize a design-system boilerplate with no
 ```sh
 npx @wfp/create-design-system my-design-system
 cd my-design-system
-yarn react:start
+yarn start:react
 ```
 
 ### Alpha releases


### PR DESCRIPTION
```npx @wfp/create-design-system@alpha my-design-system``` 

throws the following error when Lerna isn't installed globally. I was able to fix this by running `npx lerna init` instead.

![image](https://user-images.githubusercontent.com/12401179/136932260-213111ef-0b00-41ff-a54c-92270dfc915c.png)


#### Changelog

**Changed**

* use npx to run lerna init
* Fixed typo in docs 
