### PR TITLE
Added 'React.ReactNode' type to 'icon' prop of EmptyProps.

### DIFF
--- a/src/types/Empty.d.ts
+++ b/src/types/Empty.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { IIcon } from './utils';
 
-declare namespace Empty  {
+declare namespace Empty {
   interface EmptyProps extends Omit<React.HTMLProps<Empty>, 'title'> {
     title: React.ReactNode
     children?: React.ReactNode
     kind?: 'undefined' | 'large'
-    icon?: IIcon
+    icon?: IIcon | React.ReactNode
     button?: React.ReactNode
   }
 }


### PR DESCRIPTION
This PR fixes a problem only related to **Typescript**. 

The current **Empty.d.ts** declaration file doesn't allow you to pass other than an IIcon object to the **icon** prop. 
This fix is needed in order to being able to pass a Jsx element to the icon prop of the Empty component, as per [documentation](https://uikit.wfp.org/docs/index.html?path=/docs/components-ui-elements-empty--regular) (check the React code of the example with the 'Moving Van' image).
Without this fix we cannot use a static resource as icon/image for the Empty component.


#### Changelog

**Changed**

* Added 'React.ReactNode' type to the 'icon' prop of EmptyProps in Empty.d.ts.
