### PR TITLE
Fix typo

### DIFF
--- a/src/documentation/Illustrations/Illustrations.stories.mdx
+++ b/src/documentation/Illustrations/Illustrations.stories.mdx
@@ -21,7 +21,7 @@ import Illustrations from './Illustrations';
 >
 > Use the repository for a [list](https://github.com/wfp/ui/tree/master/src/assets/illustrations) of illustrations. You have created an illustration for your application? Feel free to [submit them](https://github.com/wfp/ui/issues/new).
 
-[Illustrations on Fimga](https://www.figma.com/file/C6FR4zrFuAuxHNtN9bjpy4/Illustrations?node-id=0%3A1)
+[Illustrations on Figma](https://www.figma.com/file/C6FR4zrFuAuxHNtN9bjpy4/Illustrations?node-id=0%3A1)
 
 <Illustrations />
 


### PR DESCRIPTION
Closes @wfp/ui#

Fix typo "Illustrations on Fimga" to "Illustrations on Figma"

#### Changelog

**Changed**

* Fix typo "Illustrations on Fimga" to "Illustrations on Figma"
